### PR TITLE
Gitlab unreleased badge

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,7 +9,7 @@ continuationIndent {
 
 newlines {
   sometimesBeforeColonInMethodReturnType = false
-  alwaysBeforeTopLevelStatements = true
+  alwaysBeforeTopLevelStatements = false
 }
 
 align {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.3.2
+sbt.version=1.3.4
 

--- a/server/src/main/scala/eu/monniot/simplebadges/Main.scala
+++ b/server/src/main/scala/eu/monniot/simplebadges/Main.scala
@@ -37,7 +37,7 @@ object Main extends IOApp {
       httpApp = Router(
         "/badges" -> {
           BadgesRoutes.generic[F](widthTable) <+>
-            BadgesRoutes.gitlab(widthTable, tagCache)
+            BadgesRoutes.gitlab(widthTable, tagCache, gitlab)
         }
       ).orNotFound
 

--- a/server/src/main/scala/eu/monniot/simplebadges/services/Gitlab.scala
+++ b/server/src/main/scala/eu/monniot/simplebadges/services/Gitlab.scala
@@ -10,28 +10,39 @@ import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Authorization
-import org.http4s.implicits._
 import org.http4s.util.CaseInsensitiveString
-import org.http4s.{EntityDecoder, EntityEncoder, Headers, Request, Uri}
+import org.http4s.{EntityDecoder, Headers, Request, Uri}
 
 import scala.util.control.NoStackTrace
 
 trait Gitlab[F[_]] {
   def tags(projectId: Int): F[List[Gitlab.Tag]]
+
+  // from & to are git references
+  def compare(projectId: Int, from: String, to: String): F[Gitlab.Comparison]
+
+  def commits(projectId: Int, ref: String): F[List[Gitlab.Commit]] = ???
 }
 
 object Gitlab {
   def apply[F[_]](implicit ev: Gitlab[F]): Gitlab[F] = ev
 
   final case class Tag(name: String, target: String)
-
   object Tag {
     implicit val tagDecoder: Decoder[Tag] = deriveDecoder
   }
 
-  final case class GitlabError(e: Throwable)
-      extends RuntimeException(e)
-      with NoStackTrace
+  final case class Commit(id: String, title: String)
+  object Commit {
+    implicit val commitDecoder: Decoder[Commit] = deriveDecoder
+  }
+
+  final case class Comparison(commits: List[Commit])
+  object Comparison {
+    implicit val comparisonDecoder: Decoder[Comparison] = deriveDecoder
+  }
+
+  final case class GitlabError(e: Throwable) extends RuntimeException(e) with NoStackTrace
 
   case class GitlabConfig(base: Uri, token: Option[String])
 
@@ -57,6 +68,17 @@ object Gitlab {
             Request[F](
               method = GET,
               uri = config.base / "projects" / projectId.toString / "repository" / "tags",
+              headers = authorization
+            )
+          )
+          .adaptError { case t => GitlabError(t) }
+
+      override def compare(projectId: Int, from: String, to: String): F[Comparison] =
+        client
+          .expect[Comparison](
+            Request[F](
+              method = GET,
+              uri = config.base / "projects" / projectId.toString / "repository" / "compare" +? ("from", from) +? ("to", to),
               headers = authorization
             )
           )

--- a/server/src/test/scala/eu/monniot/simplebadges/http/BadgesRoutesSpec.scala
+++ b/server/src/test/scala/eu/monniot/simplebadges/http/BadgesRoutesSpec.scala
@@ -1,14 +1,16 @@
 package eu.monniot.simplebadges.http
 
+import cats.implicits._
 import cats.effect.{Blocker, IO}
 import cats.effect.specs2.CatsIO
 import eu.monniot.badges.WidthTable
 import eu.monniot.simplebadges.services.Gitlab.Tag
-import eu.monniot.simplebadges.services.TagCache
+import eu.monniot.simplebadges.services.{Gitlab, TagCache}
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.headers.`Content-Type`
 import org.specs2.Specification
+import org.specs2.execute.Result
 import org.specs2.matcher.MatchResult
 
 class BadgesRoutesSpec extends Specification with CatsIO {
@@ -21,11 +23,18 @@ class BadgesRoutesSpec extends Specification with CatsIO {
     with a message and a label   $genericBadgesWithMessageAndLabel
     
   `gitlab` offer APIs to render badges based on GitLab status
-    using a project's latest tag as its version  $gitlabBadgeWithTag
-    render a default badge when no tag was found $gitlabBadgeWithNoTag
+    version:
+      using a project's latest tag as its version  $gitlabTagBadgeWithTag
+      render a default badge when no tag was found $gitlabTagBadgeWithNoTag
+    unreleased commits:
+      render the number of commits when no tag found     $gitlabUnreleasedNoTag
+      display the number of commits between head and ref $gitlabUnreleasedCommitsNumber
+      change the color based on the number of commits    $gitlabUnreleasedCommitsColors
   """
 
   val table: IO[WidthTable] = Blocker[IO].use(blocker => WidthTable.verdanaTable[IO](blocker))
+
+  // Generic APIs
 
   val genericBadgesWithMessage: IO[MatchResult[Any]] = {
     table
@@ -57,14 +66,38 @@ class BadgesRoutesSpec extends Specification with CatsIO {
       }
   }
 
+  // Gitlab APIs
+
   val fixedTagCache: TagCache[IO] = {
+    case i if i < 10 => IO(None)
     case 42 => IO(Some(Tag("v1.3.2", "17ffe0e699ea66c894cd4d6abe231df5f86dc4ca")))
-    case _ => IO(None)
+    case _ => IO(Some(Tag("my-tag", "bbb")))
   }
 
-  val gitlabBadgeWithTag: IO[MatchResult[Any]] =
+  val gitlab: Gitlab[IO] = new Gitlab[IO] {
+    override def tags(projectId: Int): IO[List[Tag]] = IO.raiseError(failure.exception)
+
+    override def compare(projectId: Int, from: String, to: String): IO[Gitlab.Comparison] =
+      (projectId, from, to) match {
+        case (i, _, "numbers") =>
+          IO(Gitlab.Comparison((1 to i).map(_ => Gitlab.Commit("aaa", "Update CI")).toList))
+        case (i, _, "colors") =>
+          IO(Gitlab.Comparison((1 to (i - 100)).map(_ => Gitlab.Commit("aaa", "Update CI")).toList))
+        case _ => IO.raiseError(failure.exception)
+      }
+
+    override def commits(projectId: Int, ref: String): IO[List[Gitlab.Commit]] =
+      (projectId, ref) match {
+        case (i, _) =>
+          IO((1 to i).map(_ => Gitlab.Commit("aaa", "Update CI")).toList)
+
+        case _ => IO.raiseError(failure.exception)
+      }
+  }
+
+  val gitlabTagBadgeWithTag: IO[MatchResult[Any]] =
     table
-      .map(BadgesRoutes.gitlab[IO](_, fixedTagCache).orNotFound)
+      .map(BadgesRoutes.gitlab[IO](_, fixedTagCache, gitlab).orNotFound)
       .flatMap(routes => routes(Request(Method.GET, uri"/gitlab/42/tag")))
       .map { response =>
         val st = response.status must beEqualTo(Status.Ok)
@@ -74,9 +107,9 @@ class BadgesRoutesSpec extends Specification with CatsIO {
         st and ct and bo
       }
 
-  val gitlabBadgeWithNoTag: IO[MatchResult[Any]] =
+  val gitlabTagBadgeWithNoTag: IO[MatchResult[Any]] =
     table
-      .map(BadgesRoutes.gitlab[IO](_, fixedTagCache).orNotFound)
+      .map(BadgesRoutes.gitlab[IO](_, fixedTagCache, gitlab).orNotFound)
       .flatMap(routes => routes(Request(Method.GET, uri"/gitlab/0/tag")))
       .map { response =>
         val st = response.status must beEqualTo(Status.Ok)
@@ -87,5 +120,61 @@ class BadgesRoutesSpec extends Specification with CatsIO {
 
         st and ct and bo1 and bo2
       }
+
+  val gitlabUnreleasedNoTag: IO[MatchResult[Any]] =
+    table
+      .map(BadgesRoutes.gitlab[IO](_, fixedTagCache, gitlab).orNotFound)
+      .flatMap(routes => routes(Request(Method.GET, uri"/gitlab/9/unreleased/master")))
+      .map { response =>
+        val st = response.status must beEqualTo(Status.Ok)
+        val ct = response.contentType must beSome(`Content-Type`(MediaType.application.xml))
+        val bo = response.as[String].unsafeRunSync() must contain("9 unreleased") and contain(
+          "lightgrey"
+        )
+
+        st and ct and bo
+      }
+
+  val gitlabUnreleasedCommitsNumber: IO[MatchResult[Any]] =
+    table
+      .map(BadgesRoutes.gitlab[IO](_, fixedTagCache, gitlab).orNotFound)
+      .flatMap(routes => routes(Request(Method.GET, uri"/gitlab/747/unreleased/numbers")))
+      .map { response =>
+        val st = response.status must beEqualTo(Status.Ok)
+        val ct = response.contentType must beSome(`Content-Type`(MediaType.application.xml))
+        val bo = response
+          .as[String]
+          .unsafeRunSync() must contain("747 unreleased") and not contain "lightgrey"
+
+        st and ct and bo
+      }
+
+  val gitlabUnreleasedCommitsColors: IO[Result] = {
+    def testOne(n: Int, expectedColor: String) =
+      table
+        .map(BadgesRoutes.gitlab[IO](_, fixedTagCache, gitlab).orNotFound)
+        .flatMap(
+          routes =>
+            routes(Request(Method.GET, Uri.unsafeFromString(s"/gitlab/$n/unreleased/colors")))
+        )
+        .map { response =>
+          val st = response.status must beEqualTo(Status.Ok)
+          val ct = response.contentType must beSome(`Content-Type`(MediaType.application.xml))
+          val bo = response.as[String].unsafeRunSync() must contain(expectedColor)
+
+          (st and ct and bo).toResult
+        }
+
+    Map(
+      100 + 0 -> "green",
+      100 + 2 -> "green",
+      100 + 3 -> "orange",
+      100 + 9 -> "orange",
+      100 + 10 -> "red"
+    ).map(testOne _ tupled)
+      .toList
+      .sequence
+      .map(_.fold(success)(_ and _))
+  }
 
 }


### PR DESCRIPTION
Offer a new badge to display the number of commits made to a branch since the last tag. The naming assumes that a tag is equivalent to a release.